### PR TITLE
Edit effect descriptions via double tap.

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11 (2)" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewApiLevelMustBeValid" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewFontScaleMustBeGreaterThanZero" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNotSupportedInUnitTestFiles" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/app/src/main/java/com/nima/mymood/components/EffectsListItem.kt
+++ b/app/src/main/java/com/nima/mymood/components/EffectsListItem.kt
@@ -1,6 +1,7 @@
 package com.nima.mymood.components
 
 import android.util.Log
+import android.view.GestureDetector.OnDoubleTapListener
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectVerticalDragGestures
@@ -27,7 +28,8 @@ fun EffectsListItem(
     effectRate: Int = 0,
     effectDescription: String = "",
     effectDate: String? = null,
-    onLongPress: () -> Unit
+    onLongPress: () -> Unit,
+    onDoubleTap: () -> Unit
 ) {
     ElevatedCard(
         shape = RoundedCornerShape(5.dp),
@@ -38,6 +40,9 @@ fun EffectsListItem(
                 detectTapGestures(
                     onLongPress = {
                         onLongPress()
+                    },
+                    onDoubleTap = {
+                        onDoubleTap()
                     }
                 )
             },
@@ -87,7 +92,8 @@ fun EffectsListItem(
             horizontalArrangement = Arrangement.Start
         ){
             Text(
-                text = "Long press to delete.",
+                text = "Long press to delete." +
+                        "\nDouble press to edit",
                 color = Color.Gray,
                 style = MaterialTheme.typography.labelSmall,
                 fontWeight = FontWeight.Light,

--- a/app/src/main/java/com/nima/mymood/database/MoodDao.kt
+++ b/app/src/main/java/com/nima/mymood/database/MoodDao.kt
@@ -41,6 +41,9 @@ interface MoodDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     suspend fun updateDay(day: Day)
 
+    @Update
+    suspend fun updateEffect(effect: Effect)
+
     @Delete
     suspend fun deleteDay(day: Day)
 

--- a/app/src/main/java/com/nima/mymood/repository/MoodRepository.kt
+++ b/app/src/main/java/com/nima/mymood/repository/MoodRepository.kt
@@ -39,6 +39,9 @@ class MoodRepository @Inject constructor(private val dao: MoodDao) {
     suspend fun updateDay(day: Day) =
         dao.updateDay(day)
 
+    suspend fun updateEffect(effect: Effect) =
+        dao.updateEffect(effect)
+
     suspend fun deleteDay(day: Day) =
         dao.deleteDay(day)
 

--- a/app/src/main/java/com/nima/mymood/screens/DayScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/DayScreen.kt
@@ -52,9 +52,8 @@ fun DayScreen (
         mutableStateOf(null)
     }
 
-    var showUpdateDay by remember {
-        mutableStateOf(false)
-    }
+    var newDescription by remember { mutableStateOf("") }
+
 
     if (day.value != null){
         Column(
@@ -100,42 +99,38 @@ fun DayScreen (
                 )
             }
 
-            if (updateEffect){
+            if (updateEffect) {
                 AlertDialog(
                     onDismissRequest = {
-                        deleteEffect = false
-                        effectToDelete = null
+                        updateEffect = false
+                        effectToUpdate = null
+                        newDescription = ""
                     },
-                    dismissButton = {
-                        TextButton(onClick = {
-                            deleteEffect = false
-                            effectToDelete = null
-                        }) {
-                            Text(text = "Cancel")
-                        }
+                    text = {
+                        TextField(
+                            value = newDescription,
+                            onValueChange = {
+                                newDescription = it
+                            }
+                        )
                     },
                     confirmButton = {
                         TextButton(onClick = {
-                            viewModel.deleteEffect(effectToDelete!!).invokeOnCompletion {
-                                deleteEffect = false
-                                effectToDelete = null
+                            viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                                updateEffect = false
+                                effectToUpdate = null
+                                newDescription = ""
                             }
                         }) {
                             Text(text = "Confirm")
                         }
                     },
-                    icon = {
-                        Icon(imageVector = Icons.Default.Delete, contentDescription = null)
-                    },
-                    text = {
-                        Text(text = "You are about to delete an effect from your day! Remember that effects will not be deleted from your life." +
-                                "\nDo you want to permanently delete this effect?")
-                    },
                     title = {
-                        Text(text = "Delete Effect?")
+                        Text(text = "Update Effect")
                     }
                 )
             }
+
 
             if (showDeleteDay){
 

--- a/app/src/main/java/com/nima/mymood/screens/DayScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/DayScreen.kt
@@ -1,5 +1,6 @@
 package com.nima.mymood.screens
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -43,6 +44,18 @@ fun DayScreen (
         mutableStateOf(false)
     }
 
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
+        mutableStateOf(null)
+    }
+
+    var showUpdateDay by remember {
+        mutableStateOf(false)
+    }
+
     if (day.value != null){
         Column(
             modifier = Modifier.fillMaxSize(),
@@ -51,6 +64,43 @@ fun DayScreen (
         ) {
 
             if (deleteEffect){
+                AlertDialog(
+                    onDismissRequest = {
+                        deleteEffect = false
+                        effectToDelete = null
+                    },
+                    dismissButton = {
+                        TextButton(onClick = {
+                            deleteEffect = false
+                            effectToDelete = null
+                        }) {
+                            Text(text = "Cancel")
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.deleteEffect(effectToDelete!!).invokeOnCompletion {
+                                deleteEffect = false
+                                effectToDelete = null
+                            }
+                        }) {
+                            Text(text = "Confirm")
+                        }
+                    },
+                    icon = {
+                        Icon(imageVector = Icons.Default.Delete, contentDescription = null)
+                    },
+                    text = {
+                        Text(text = "You are about to delete an effect from your day! Remember that effects will not be deleted from your life." +
+                                "\nDo you want to permanently delete this effect?")
+                    },
+                    title = {
+                        Text(text = "Delete Effect?")
+                    }
+                )
+            }
+
+            if (updateEffect){
                 AlertDialog(
                     onDismissRequest = {
                         deleteEffect = false
@@ -175,11 +225,16 @@ fun DayScreen (
                 }){
                     EffectsListItem(
                         it.rate,
-                        it.description
-                    ){
-                        effectToDelete = it
-                        deleteEffect = true
-                    }
+                        it.description,
+                        onLongPress = {
+                            effectToDelete = it
+                            deleteEffect = true
+                        },
+                        onDoubleTap = {
+                            effectToUpdate = it
+                            updateEffect = true
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/nima/mymood/screens/HappyEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/HappyEffectsScreen.kt
@@ -44,6 +44,9 @@ fun HappyEffectsScreen (
         mutableStateOf(null)
     }
 
+    var newDescription by remember { mutableStateOf("") }
+
+
     if (happyEffects.value.isEmpty()){
         Column(
             modifier = Modifier
@@ -109,8 +112,38 @@ fun HappyEffectsScreen (
                     }
                 )
             }
-            if (updateEffect){
+            if (updateEffect) {
+                AlertDialog(
+                    onDismissRequest = {
+                        updateEffect = false
+                        effectToUpdate = null
+                        newDescription = ""
+                    },
+                    text = {
+                        TextField(
+                            value = newDescription,
+                            onValueChange = {
+                                newDescription = it
+                            }
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                                updateEffect = false
+                                effectToUpdate = null
+                                newDescription = ""
+                            }
+                        }) {
+                            Text(text = "Confirm")
+                        }
+                    },
+                    title = {
+                        Text(text = "Update Effect")
+                    }
+                )
             }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 32.dp, end = 32.dp, top = 16.dp),

--- a/app/src/main/java/com/nima/mymood/screens/HappyEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/HappyEffectsScreen.kt
@@ -1,5 +1,6 @@
 package com.nima.mymood.screens
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -33,6 +34,13 @@ fun HappyEffectsScreen (
     }
 
     var effectToDelete: Effect? by remember {
+        mutableStateOf(null)
+    }
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
         mutableStateOf(null)
     }
 
@@ -101,6 +109,8 @@ fun HappyEffectsScreen (
                     }
                 )
             }
+            if (updateEffect){
+            }
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 32.dp, end = 32.dp, top = 16.dp),
@@ -129,11 +139,15 @@ fun HappyEffectsScreen (
                         EffectsListItem(
                             it.rate,
                             it.description,
-                            date
-                        ) {
-                            effectToDelete = it
-                            deleteEffect = true
-                        }
+                            onLongPress = {
+                                effectToDelete = it
+                                deleteEffect = true
+                            },
+                            onDoubleTap = {
+                                effectToUpdate = it
+                                updateEffect = true
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/nima/mymood/screens/HomeScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/HomeScreen.kt
@@ -82,6 +82,8 @@ fun HomeScreen(
         mutableStateOf(null)
     }
 
+    var newDescription by remember { mutableStateOf("") }
+
     val today = produceState<Day?>(initialValue = null){
         value = viewModel.getDayByDate(year, month, day)
     }.value
@@ -90,7 +92,6 @@ fun HomeScreen(
         mutableStateOf(false)
     }
 
-    var newDescription by remember { mutableStateOf("") }
 
     val datePickerState = rememberDatePickerState()
     datePickerState.displayMode = DisplayMode.Input
@@ -138,12 +139,12 @@ fun HomeScreen(
             )
         }
 
-
         if (updateEffect) {
             AlertDialog(
                 onDismissRequest = {
                     updateEffect = false
                     effectToUpdate = null
+                    newDescription = ""
                 },
                 text = {
                     TextField1(
@@ -158,6 +159,7 @@ fun HomeScreen(
                         viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
                             updateEffect = false
                             effectToUpdate = null
+                            newDescription = ""
                         }
                     }) {
                         Text(text = "Confirm")

--- a/app/src/main/java/com/nima/mymood/screens/HomeScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/HomeScreen.kt
@@ -2,6 +2,8 @@ package com.nima.mymood.screens
 
 import android.annotation.SuppressLint
 import android.util.Log
+import android.widget.EditText
+import android.widget.Toast
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -36,6 +38,7 @@ import com.nima.mymood.viewmodels.HomeViewModel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.util.*
+import androidx.compose.material3.TextField as TextField1
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @OptIn(ExperimentalMaterial3Api::class)
@@ -70,7 +73,15 @@ fun HomeScreen(
     var effectToDelete: Effect? by remember {
         mutableStateOf(null)
     }
-    
+
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
+        mutableStateOf(null)
+    }
+
     val today = produceState<Day?>(initialValue = null){
         value = viewModel.getDayByDate(year, month, day)
     }.value
@@ -78,6 +89,8 @@ fun HomeScreen(
     var showDatePicker by remember {
         mutableStateOf(false)
     }
+
+    var newDescription by remember { mutableStateOf("") }
 
     val datePickerState = rememberDatePickerState()
     datePickerState.displayMode = DisplayMode.Input
@@ -124,6 +137,38 @@ fun HomeScreen(
                 }
             )
         }
+
+
+        if (updateEffect) {
+            AlertDialog(
+                onDismissRequest = {
+                    updateEffect = false
+                    effectToUpdate = null
+                },
+                text = {
+                    TextField1(
+                        value = newDescription,
+                        onValueChange = {
+                            newDescription = it
+                        }
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = {
+                        viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                            updateEffect = false
+                            effectToUpdate = null
+                        }
+                    }) {
+                        Text(text = "Confirm")
+                    }
+                },
+                title = {
+                    Text(text = "Update Effect")
+                }
+            )
+        }
+
 
         if (showDatePicker){
             DatePickerDialog(
@@ -306,11 +351,16 @@ fun HomeScreen(
                             }) {
                                 EffectsListItem(
                                     it.rate,
-                                    it.description
-                                ) {
-                                    effectToDelete = it
-                                    deleteEffect = true
-                                }
+                                    it.description,
+                                    onLongPress = {
+                                        effectToDelete = it
+                                        deleteEffect = true
+                                },
+                                    onDoubleTap = {
+                                        effectToUpdate = it
+                                        updateEffect = true
+                                    }
+                            )
                             }
                         }
                     }

--- a/app/src/main/java/com/nima/mymood/screens/NeutralEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/NeutralEffectsScreen.kt
@@ -46,6 +46,8 @@ fun NeutralEffectsScreen(
         mutableStateOf(null)
     }
 
+    var newDescription by remember { mutableStateOf("") }
+
     if (neutralEffects.value.isEmpty()){
         Column(
             modifier = Modifier
@@ -111,10 +113,38 @@ fun NeutralEffectsScreen(
                     }
                 )
             }
-
-            if (updateEffect){
-                Log.d("neu", "Update")
+            if (updateEffect) {
+                AlertDialog(
+                    onDismissRequest = {
+                        updateEffect = false
+                        effectToUpdate = null
+                        newDescription = ""
+                    },
+                    text = {
+                        TextField(
+                            value = newDescription,
+                            onValueChange = {
+                                newDescription = it
+                            }
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                                updateEffect = false
+                                effectToUpdate = null
+                                newDescription = ""
+                            }
+                        }) {
+                            Text(text = "Confirm")
+                        }
+                    },
+                    title = {
+                        Text(text = "Update Effect")
+                    }
+                )
             }
+
 
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/app/src/main/java/com/nima/mymood/screens/NeutralEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/NeutralEffectsScreen.kt
@@ -1,5 +1,6 @@
 package com.nima.mymood.screens
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -34,6 +35,14 @@ fun NeutralEffectsScreen(
     }
 
     var effectToDelete: Effect? by remember {
+        mutableStateOf(null)
+    }
+
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
         mutableStateOf(null)
     }
 
@@ -103,6 +112,10 @@ fun NeutralEffectsScreen(
                 )
             }
 
+            if (updateEffect){
+                Log.d("neu", "Update")
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 32.dp, end = 32.dp, top = 16.dp),
@@ -131,11 +144,15 @@ fun NeutralEffectsScreen(
                         EffectsListItem(
                             it.rate,
                             it.description,
-                            date
-                        ) {
-                            effectToDelete = it
-                            deleteEffect = true
-                        }
+                            onLongPress = {
+                                effectToDelete = it
+                                deleteEffect = true
+                            },
+                            onDoubleTap = {
+                                effectToUpdate = it
+                                updateEffect = true
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/nima/mymood/screens/SadEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/SadEffectsScreen.kt
@@ -1,5 +1,6 @@
 package com.nima.mymood.screens
 
+import android.util.Log
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -39,6 +40,14 @@ fun SadEffectsScreen(
     }
 
     var effectToDelete: Effect? by remember {
+        mutableStateOf(null)
+    }
+
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
         mutableStateOf(null)
     }
 
@@ -109,6 +118,9 @@ fun SadEffectsScreen(
                     }
                 )
             }
+
+            if (updateEffect){
+            }
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(start = 32.dp, end = 32.dp, top = 16.dp),
@@ -138,11 +150,15 @@ fun SadEffectsScreen(
                         EffectsListItem(
                             it.rate,
                             it.description,
-                            date
-                        ) {
-                            effectToDelete = it
-                            deleteEffect = true
-                        }
+                            onLongPress = {
+                                effectToDelete = it
+                                deleteEffect = true
+                            },
+                            onDoubleTap = {
+                                effectToUpdate = it
+                                updateEffect = true
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/nima/mymood/screens/SadEffectsScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/SadEffectsScreen.kt
@@ -47,6 +47,8 @@ fun SadEffectsScreen(
         mutableStateOf(false)
     }
 
+    var newDescription by remember { mutableStateOf("") }
+
     var effectToUpdate: Effect? by remember {
         mutableStateOf(null)
     }
@@ -118,49 +120,36 @@ fun SadEffectsScreen(
                     }
                 )
             }
-
-            if (updateEffect){
-            }
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                contentPadding = PaddingValues(start = 32.dp, end = 32.dp, top = 16.dp),
-                verticalArrangement = Arrangement.Top,
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                items(items = sadEffects.value, key ={
-                    it.id
-                }) {
-
-                    Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.Center,
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ){
-
-                        var date: String? by remember {
-                            mutableStateOf(null)
-                        }
-
-                        LaunchedEffect(key1 = Unit){
-                            viewModel.getDayById(it.foreignKey).collectLatest {
-                                date = "${it.day}/${it.month}/${it.year}"
-                            }
-                        }
-
-                        EffectsListItem(
-                            it.rate,
-                            it.description,
-                            onLongPress = {
-                                effectToDelete = it
-                                deleteEffect = true
-                            },
-                            onDoubleTap = {
-                                effectToUpdate = it
-                                updateEffect = true
+            if (updateEffect) {
+                AlertDialog(
+                    onDismissRequest = {
+                        updateEffect = false
+                        effectToUpdate = null
+                        newDescription = ""
+                    },
+                    text = {
+                        TextField(
+                            value = newDescription,
+                            onValueChange = {
+                                newDescription = it
                             }
                         )
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                                updateEffect = false
+                                effectToUpdate = null
+                                newDescription = ""
+                            }
+                        }) {
+                            Text(text = "Confirm")
+                        }
+                    },
+                    title = {
+                        Text(text = "Update Effect")
                     }
-                }
+                )
             }
         }
     }

--- a/app/src/main/java/com/nima/mymood/screens/TodayMoodScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/TodayMoodScreen.kt
@@ -1,6 +1,7 @@
 package com.nima.mymood.screens
 
 import android.util.Log
+import android.widget.Toast
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -61,6 +62,13 @@ fun TodayMoodScreen(
     var effectToDelete: Effect? by remember {
         mutableStateOf(null)
     }
+    var updateEffect by remember {
+        mutableStateOf(false)
+    }
+
+    var effectToUpdate: Effect? by remember {
+        mutableStateOf(null)
+    }
 
     val effectsList = viewModel.getDayEffects(UUID.fromString(id!!)).collectAsState(initial = emptyList())
 
@@ -74,6 +82,43 @@ fun TodayMoodScreen(
         ) {
 
             if (deleteEffect){
+                AlertDialog(
+                    onDismissRequest = {
+                        deleteEffect = false
+                        effectToDelete = null
+                    },
+                    dismissButton = {
+                        TextButton(onClick = {
+                            deleteEffect = false
+                            effectToDelete = null
+                        }) {
+                            Text(text = "Cancel")
+                        }
+                    },
+                    confirmButton = {
+                        TextButton(onClick = {
+                            viewModel.deleteEffect(effectToDelete!!).invokeOnCompletion {
+                                deleteEffect = false
+                                effectToDelete = null
+                            }
+                        }) {
+                            Text(text = "Confirm")
+                        }
+                    },
+                    icon = {
+                        Icon(imageVector = Icons.Default.Delete, contentDescription = null)
+                    },
+                    text = {
+                        Text(text = "You are about to delete an effect from your day! Remember that effects will not be deleted from your life." +
+                                "\nDo you want to permanently delete this effect?")
+                    },
+                    title = {
+                        Text(text = "Delete Effect?")
+                    }
+                )
+            }
+
+            if (updateEffect){
                 AlertDialog(
                     onDismissRequest = {
                         deleteEffect = false
@@ -308,12 +353,17 @@ fun TodayMoodScreen(
                         horizontalArrangement = Arrangement.Start
                     ) {
                         EffectsListItem(
-                            effectRate = it.rate,
-                            effectDescription = it.description
-                        ){
-                            effectToDelete = it
-                            deleteEffect = true
-                        }
+                            it.rate,
+                            it.description,
+                            onLongPress = {
+                                effectToDelete = it
+                                deleteEffect = true
+                            },
+                            onDoubleTap = {
+                                effectToUpdate = it
+                                updateEffect = true
+                            }
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/nima/mymood/screens/TodayMoodScreen.kt
+++ b/app/src/main/java/com/nima/mymood/screens/TodayMoodScreen.kt
@@ -1,7 +1,6 @@
 package com.nima.mymood.screens
 
 import android.util.Log
-import android.widget.Toast
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -62,6 +61,7 @@ fun TodayMoodScreen(
     var effectToDelete: Effect? by remember {
         mutableStateOf(null)
     }
+
     var updateEffect by remember {
         mutableStateOf(false)
     }
@@ -70,6 +70,7 @@ fun TodayMoodScreen(
         mutableStateOf(null)
     }
 
+    var newDescription by remember { mutableStateOf("") }
     val effectsList = viewModel.getDayEffects(UUID.fromString(id!!)).collectAsState(initial = emptyList())
 
     if (day.value != null){
@@ -118,39 +119,34 @@ fun TodayMoodScreen(
                 )
             }
 
-            if (updateEffect){
+            if (updateEffect) {
                 AlertDialog(
                     onDismissRequest = {
-                        deleteEffect = false
-                        effectToDelete = null
+                        updateEffect = false
+                        effectToUpdate = null
+                        newDescription = ""
                     },
-                    dismissButton = {
-                        TextButton(onClick = {
-                            deleteEffect = false
-                            effectToDelete = null
-                        }) {
-                            Text(text = "Cancel")
-                        }
+                    text = {
+                        TextField(
+                            value = newDescription,
+                            onValueChange = {
+                                newDescription = it
+                            }
+                        )
                     },
                     confirmButton = {
                         TextButton(onClick = {
-                            viewModel.deleteEffect(effectToDelete!!).invokeOnCompletion {
-                                deleteEffect = false
-                                effectToDelete = null
+                            viewModel.updateEffect(effectToUpdate!!.copy(description = newDescription)).invokeOnCompletion {
+                                updateEffect = false
+                                effectToUpdate = null
+                                newDescription = ""
                             }
                         }) {
                             Text(text = "Confirm")
                         }
                     },
-                    icon = {
-                        Icon(imageVector = Icons.Default.Delete, contentDescription = null)
-                    },
-                    text = {
-                        Text(text = "You are about to delete an effect from your day! Remember that effects will not be deleted from your life." +
-                                "\nDo you want to permanently delete this effect?")
-                    },
                     title = {
-                        Text(text = "Delete Effect?")
+                        Text(text = "Update Effect")
                     }
                 )
             }

--- a/app/src/main/java/com/nima/mymood/viewmodels/DayViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/DayViewModel.kt
@@ -28,4 +28,8 @@ class DayViewModel @Inject constructor(private val repository: MoodRepository)
         viewModelScope.launch {
             repository.deleteDay(day)
         }
+
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
 }

--- a/app/src/main/java/com/nima/mymood/viewmodels/HappyEffectsViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/HappyEffectsViewModel.kt
@@ -22,4 +22,7 @@ class HappyEffectsViewModel @Inject constructor(private val repository: MoodRepo
     }
 
     fun getDayById(id: UUID) = repository.getDayById(id).distinctUntilChanged()
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
 }

--- a/app/src/main/java/com/nima/mymood/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/HomeViewModel.kt
@@ -28,4 +28,7 @@ class HomeViewModel @Inject constructor(
     fun deleteEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
         repository.deleteEffect(effect)
     }
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
 }

--- a/app/src/main/java/com/nima/mymood/viewmodels/MenuViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/MenuViewModel.kt
@@ -6,6 +6,7 @@ import com.nima.mymood.model.Day
 import com.nima.mymood.model.Effect
 import com.nima.mymood.repository.MoodRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import java.util.UUID
@@ -21,6 +22,10 @@ class MenuViewModel @Inject constructor(private val repository: MoodRepository)
 
     fun addDay(day: Day) = viewModelScope.launch {
         repository.addDay(day)
+    }
+
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
     }
 
     fun addEffect(effect: Effect) = viewModelScope.launch {

--- a/app/src/main/java/com/nima/mymood/viewmodels/NeutralEffectsViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/NeutralEffectsViewModel.kt
@@ -24,5 +24,8 @@ class NeutralEffectsViewModel @Inject constructor(private val repository: MoodRe
 
     fun getDayById(id: UUID) = repository.getDayById(id).distinctUntilChanged()
 
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
 
 }

--- a/app/src/main/java/com/nima/mymood/viewmodels/SadEffectsViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/SadEffectsViewModel.kt
@@ -24,4 +24,8 @@ class SadEffectsViewModel @Inject constructor(private val repository: MoodReposi
 
     fun getDayById(id: UUID) = repository.getDayById(id).distinctUntilChanged()
 
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
+
 }

--- a/app/src/main/java/com/nima/mymood/viewmodels/TodayMoodViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/TodayMoodViewModel.kt
@@ -20,7 +20,9 @@ class TodayMoodViewModel @Inject constructor(private val repository: MoodReposit
 
     suspend fun updateDay(day: Day) = repository.updateDay(day)
 
-    suspend fun updateEffect(effect: Effect) = repository.updateEffect(effect)
+    fun updateEffect(effect: Effect) = viewModelScope.launch(Dispatchers.IO) {
+        repository.updateEffect(effect)
+    }
 
     fun getDayById(id: UUID) = repository.getDayById(id).distinctUntilChanged()
 

--- a/app/src/main/java/com/nima/mymood/viewmodels/TodayMoodViewModel.kt
+++ b/app/src/main/java/com/nima/mymood/viewmodels/TodayMoodViewModel.kt
@@ -20,6 +20,8 @@ class TodayMoodViewModel @Inject constructor(private val repository: MoodReposit
 
     suspend fun updateDay(day: Day) = repository.updateDay(day)
 
+    suspend fun updateEffect(effect: Effect) = repository.updateEffect(effect)
+
     fun getDayById(id: UUID) = repository.getDayById(id).distinctUntilChanged()
 
     fun getDayEffects(fk: UUID) = repository.getEffectsByFK(fk).distinctUntilChanged()


### PR DESCRIPTION
Partially solves #16 

Add the ability to double tap a effect list item and update it in the database to have a new description set by a dialog that pops up from a double tap action on the effect list item. Update UI of every effect list item to mention double tapping to update. Lays the blueprint for updating the rate of a effect via dialog. 


![Screenshot_20230429-202816-047](https://user-images.githubusercontent.com/75283919/235332693-9afe90c3-18ab-4b8b-a6d5-8cd0266a6f00.png)
